### PR TITLE
Wrong index.html path

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,7 +14,7 @@ const app = new Application();
 app.use(viewEngine(oakAdapter, denjuckEngine));
 
 app.use(async (ctx, next) => {
-  ctx.render("./view/index.html", { data: { name: "John" } });
+  ctx.render("index.html", { data: { name: "John" } });
 });
 
 await app.listen({ port: 8000 });


### PR DESCRIPTION
For Denjucks engine template, it point to wrong path of index.html in app.ts file. So it cannot render a webpage and got an error message in console :
 

> "The character encoding of the plain text document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the file needs to be declared in the transfer protocol or file needs to use a byte order mark as an encoding signature."

**Solution:** Please check the view path of each engine template.